### PR TITLE
improve color contrast

### DIFF
--- a/template/main.scss
+++ b/template/main.scss
@@ -68,12 +68,12 @@ span.switch {
 		transition: opacity 0.3s;
 
 		&:first-child {
-			color: #a70;
+			color: #a60;
 			opacity: 1;
 		}
 
 		&:last-child {
-			color: #0af;
+			color: #09e;
 			opacity: 0;
 		}
 	}


### PR DESCRIPTION
See https://www.w3.org/TR/WCAG22/#contrast-minimum

I was a bit flexible and treated this as "large text", i.e. a minimum contrast of 3. Otherwise the contrast would need to be at least 4.5.

- https://xi.github.io/contrast/#%23a70-on-%23E6D6C5
- https://xi.github.io/contrast/#%230af-on-%23fff